### PR TITLE
Implement support for Bluetooth devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,15 @@ This library provides a unified API to query and interact with all kinds of hard
 
 Current backends:
 - Solid
+- Bluetooth
 
 ## Dependencies
 - Solid (https://api.kde.org/frameworks/solid/html/index.html)
   - build deps: flex/bison, udev, extra-cmake-modules
   - manual build: usually just a matter of `sudo apt build-dep solid` for Ubuntu or `sudo dnf builddep kf5-solid` for Fedora
   - runtime deps: udisks2 (dbus), MediaPlayerInfo (optional)
+- Qt Bluetooth (http://doc.qt.io/qt-5/qtbluetooth-index.html)
+  - runtime deps: dbus, bluez
 
 ## License
 Copyright (C) 2017 Pelagicore AB

--- a/src/lib/bluetooth/bluetoothbackend.cpp
+++ b/src/lib/bluetooth/bluetoothbackend.cpp
@@ -1,0 +1,174 @@
+/*
+ *   Copyright (C) 2017 Pelagicore AB
+ *
+ *   Author: Lukáš Tinkl <ltinkl@luxoft.com>
+ *
+ *   This library is free software; you can redistribute it and/or
+ *   modify it under the terms of the GNU Lesser General Public License
+ *   as published by the Free Software Foundation; version 2.1.
+ *
+ *   This library is distributed in the hope that it will be useful, but
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *   Lesser General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Lesser General Public
+ *   License along with this library; if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ *   MA 02110-1301 USA
+ *
+ *   SPDX-License-Identifier: LGPL-2.1
+ *
+ */
+
+#include <QDebug>
+#include <QtGlobal>
+#include <QTimer>
+
+#include "bluetoothbackend.h"
+#include "peluxbtdevice.h"
+
+BluetoothBackend::BluetoothBackend(QObject *parent)
+    : QObject(parent)
+    , m_btDevice(new QBluetoothLocalDevice)
+    , m_btAgent(new QBluetoothServiceDiscoveryAgent(this))
+    , m_rfKill(new BluezQt::Rfkill(this))
+{
+    qInfo() << "Local BT device:" << m_btDevice->name() << m_btDevice->hostMode();
+    connect(m_btDevice.data(), &QBluetoothLocalDevice::hostModeStateChanged, this, &BluetoothBackend::onHostModeStateChanged);
+    connect(m_btDevice.data(), &QBluetoothLocalDevice::pairingDisplayConfirmation, [this](const QBluetoothAddress &address, QString pin) {
+        qInfo() << "!!! Display pairing confirmation from" << address.toString() << pin;
+        Q_EMIT pairingConfirmation(address.toString(), pin);
+    });
+    connect(m_btDevice.data(), &QBluetoothLocalDevice::pairingDisplayPinCode, [this](const QBluetoothAddress &address, QString pin) {
+        qInfo() << "!!! Display pairing pin from" << address.toString() << pin;
+        Q_EMIT pairingConfirmation(address.toString(), pin);
+    });
+
+    connect(m_btAgent, &QBluetoothServiceDiscoveryAgent::serviceDiscovered, this, &BluetoothBackend::onServiceDiscovered);
+    connect(m_btAgent, QOverload<QBluetoothServiceDiscoveryAgent::Error>::of(&QBluetoothServiceDiscoveryAgent::error),
+            this, &BluetoothBackend::onDiscoveryError);
+    connect(m_btAgent, &QBluetoothServiceDiscoveryAgent::finished, [this]() {
+        setDiscoveryActive(false);
+    });
+    connect(m_btAgent, &QBluetoothServiceDiscoveryAgent::canceled, [this]() {
+        setDiscoveryActive(false);
+    });
+
+    connect(m_rfKill, &BluezQt::Rfkill::stateChanged, [this](BluezQt::Rfkill::State state) {
+        if (state != BluezQt::Rfkill::Unblocked) { // rfkill turned off?
+            clearDevices();
+            setDiscoveryActive(false);
+        }
+    });
+
+    for(const QBluetoothServiceInfo &service: m_btAgent->discoveredServices()) {
+        onServiceDiscovered(service);
+    }
+}
+
+QVector<PeluxDevice *> BluetoothBackend::allDevices() const
+{
+    return m_devices;
+}
+
+int BluetoothBackend::count() const
+{
+    return m_devices.count();
+}
+
+void BluetoothBackend::startDiscovery()
+{
+    if (m_rfKill->state() == BluezQt::Rfkill::Unblocked) {
+        doStartDiscovery();
+    } else if (m_rfKill->unblock()) {
+        // wait a bit until the device is really available; even if it's unblocked, it still takes some time
+        setDiscoveryActive(true);
+        QTimer::singleShot(3000, this, &BluetoothBackend::doStartDiscovery);
+    } else {
+        qWarning() << Q_FUNC_INFO << "Unusable or hard-blocked Bluetooth adapter! Try powering it on manually first";
+    }
+}
+
+void BluetoothBackend::doStartDiscovery()
+{
+    // this may contain stale reference when the rfkill is turned off/on
+    // so always grab a new pointer when starting the device discovery
+    m_btDevice.reset(new QBluetoothLocalDevice);
+
+    if (m_btDevice->isValid()) {
+        if (m_btAgent->isActive()) {
+            qWarning() << Q_FUNC_INFO << "Bluetooth discovery already in progress";
+            return;
+        }
+
+        setDiscoveryActive(true);
+        m_btDevice->powerOn();
+        m_btDevice->setHostMode(QBluetoothLocalDevice::HostDiscoverable);
+        clearDevices();
+        m_btAgent->start();
+    } else {
+        qWarning() << Q_FUNC_INFO << "Local Bluetooth adapter invalid! Power it on manually first";
+    }
+}
+
+void BluetoothBackend::stopDiscovery()
+{
+    m_btAgent->stop();
+}
+
+bool BluetoothBackend::isDiscoveryActive() const
+{
+    return m_discoveryActive;
+}
+
+void BluetoothBackend::confirmPairing(bool accept)
+{
+    m_btDevice->pairingConfirmation(accept);
+}
+
+void BluetoothBackend::onServiceDiscovered(const QBluetoothServiceInfo &info)
+{
+    if (!info.isValid() || info.serviceClassUuids().isEmpty() || info.serviceName().isEmpty()) { // discard bogus services
+        return;
+    }
+
+    qInfo() << "Service discovered:" << info.serviceName() << info.serviceDescription();
+    qInfo() << "\ton device:" << info.device().name() << info.device().address().toString();
+    qInfo() << "\tservice:" << info.serviceClassUuids().first();
+
+    PeluxBluetoothDevice *dev = new PeluxBluetoothDevice(info, m_btDevice.data(), this);
+    m_devices.append(dev);
+    Q_EMIT deviceAdded(dev);
+}
+
+void BluetoothBackend::onDiscoveryError(QBluetoothServiceDiscoveryAgent::Error error)
+{
+    qWarning() << Q_FUNC_INFO << error << m_btAgent->errorString();
+    setDiscoveryActive(m_btAgent->isActive());
+}
+
+void BluetoothBackend::onHostModeStateChanged(QBluetoothLocalDevice::HostMode state)
+{
+    qInfo() << "BT mode changed:" << state;
+    if (state == QBluetoothLocalDevice::HostPoweredOff) {
+        clearDevices();
+    }
+}
+
+void BluetoothBackend::clearDevices()
+{
+    for (PeluxDevice *dev: m_devices) {
+        Q_EMIT deviceRemoved(dev);
+    }
+    m_devices.clear();
+    m_btAgent->clear();
+}
+
+void BluetoothBackend::setDiscoveryActive(bool active)
+{
+    if (active != m_discoveryActive) {
+        m_discoveryActive = active;
+        Q_EMIT isDiscoveryActiveChanged(m_discoveryActive);
+    }
+}

--- a/src/lib/bluetooth/bluetoothbackend.h
+++ b/src/lib/bluetooth/bluetoothbackend.h
@@ -1,0 +1,73 @@
+/*
+ *   Copyright (C) 2017 Pelagicore AB
+ *
+ *   Author: Lukáš Tinkl <ltinkl@luxoft.com>
+ *
+ *   This library is free software; you can redistribute it and/or
+ *   modify it under the terms of the GNU Lesser General Public License
+ *   as published by the Free Software Foundation; version 2.1.
+ *
+ *   This library is distributed in the hope that it will be useful, but
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *   Lesser General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Lesser General Public
+ *   License along with this library; if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ *   MA 02110-1301 USA
+ *
+ *   SPDX-License-Identifier: LGPL-2.1
+ *
+ */
+
+#pragma once
+
+#include <QObject>
+#include <QVector>
+
+#include <QBluetoothLocalDevice>
+#include <QBluetoothServiceDiscoveryAgent>
+
+#include "peluxbtdevice.h"
+#include "rfkill.h"
+
+class BluetoothBackend : public QObject
+{
+    Q_OBJECT
+public:
+    explicit BluetoothBackend(QObject *parent = nullptr);
+    ~BluetoothBackend() = default;
+
+    QVector<PeluxDevice *> allDevices() const;
+    int count() const;
+
+    void startDiscovery();
+    void stopDiscovery();
+
+    bool isDiscoveryActive() const;
+
+    void confirmPairing(bool accept);
+
+Q_SIGNALS:
+    void deviceAdded(PeluxDevice *dev);
+    void deviceRemoved(PeluxDevice *dev);
+    void isDiscoveryActiveChanged(bool active);
+
+    void pairingConfirmation(const QString &address, const QString &pin);
+
+private Q_SLOTS:
+    void onServiceDiscovered(const QBluetoothServiceInfo &info);
+    void onDiscoveryError(QBluetoothServiceDiscoveryAgent::Error error);
+    void onHostModeStateChanged(QBluetoothLocalDevice::HostMode state);
+
+private:
+    void doStartDiscovery();
+    void clearDevices();
+    void setDiscoveryActive(bool active);
+    QVector<PeluxDevice *> m_devices;
+    QScopedPointer<QBluetoothLocalDevice> m_btDevice;
+    QBluetoothServiceDiscoveryAgent *m_btAgent{nullptr};
+    BluezQt::Rfkill *m_rfKill{nullptr};
+    bool m_discoveryActive{false};
+};

--- a/src/lib/bluetooth/peluxbtdevice.cpp
+++ b/src/lib/bluetooth/peluxbtdevice.cpp
@@ -1,0 +1,225 @@
+/*
+ *   Copyright (C) 2017 Pelagicore AB
+ *
+ *   Author: Lukáš Tinkl <ltinkl@luxoft.com>
+ *
+ *   This library is free software; you can redistribute it and/or
+ *   modify it under the terms of the GNU Lesser General Public License
+ *   as published by the Free Software Foundation; version 2.1.
+ *
+ *   This library is distributed in the hope that it will be useful, but
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *   Lesser General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Lesser General Public
+ *   License along with this library; if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ *   MA 02110-1301 USA
+ *
+ *   SPDX-License-Identifier: LGPL-2.1
+ *
+ */
+
+#include <QDebug>
+#include <QBluetoothDeviceInfo>
+
+#include "peluxbtdevice.h"
+
+PeluxBluetoothDevice::PeluxBluetoothDevice(const QBluetoothServiceInfo &btInfo, QBluetoothLocalDevice *btLocalDev, QObject *parent)
+    : PeluxDevice(parent)
+    , m_info(btInfo)
+    , m_btLocalDevice(btLocalDev)
+{
+    m_id = m_info.device().address().toString() + QStringLiteral("_") + m_info.serviceClassUuids().first().toString();
+
+    connect(m_btLocalDevice.data(), &QBluetoothLocalDevice::error, [this](QBluetoothLocalDevice::Error error) {
+        qWarning() << "Pairing error" << device() << error;
+        updateStatus(PeluxDeviceManagerEnums::Unpaired);
+    });
+
+    updateStatus(PeluxDeviceManagerEnums::Disconnected);
+    checkConnectionStatus();
+}
+
+QString PeluxBluetoothDevice::id() const
+{
+    return m_id;
+}
+
+QString PeluxBluetoothDevice::parentId() const
+{
+    return QString();
+}
+
+PeluxDeviceManagerEnums::DeviceType PeluxBluetoothDevice::deviceType() const
+{
+    return PeluxDeviceManagerEnums::Bluetooth;
+}
+
+QString PeluxBluetoothDevice::vendor() const
+{
+    return m_info.serviceProvider();
+}
+
+QString PeluxBluetoothDevice::product() const
+{
+    return m_info.device().name();
+}
+
+QString PeluxBluetoothDevice::description() const
+{
+    QString text = m_info.serviceName();
+    if (!m_info.serviceDescription().isEmpty()) {
+        text.append(QStringLiteral(" (") + m_info.serviceDescription() + QStringLiteral(")"));
+    }
+    return text;
+}
+
+QString PeluxBluetoothDevice::icon() const
+{
+    // FIXME maybe use QBluetoothDeviceInfo::majorDeviceClass() to differentiate
+    return QStringLiteral("bluetooth");
+}
+
+QStringList PeluxBluetoothDevice::emblems() const
+{
+    // FIXME ditto as icon()
+    return {};
+}
+
+QString PeluxBluetoothDevice::mountPoint() const
+{
+    // TODO
+    return QString();
+}
+
+QString PeluxBluetoothDevice::device() const
+{
+    return m_info.device().address().toString();
+}
+
+bool PeluxBluetoothDevice::isRemovable() const
+{
+    return true;
+}
+
+PeluxDeviceManagerEnums::DriveType PeluxBluetoothDevice::driveType() const
+{
+    return PeluxDeviceManagerEnums::UnknownDriveType;
+}
+
+QString PeluxBluetoothDevice::uuid() const
+{
+    return !m_info.serviceClassUuids().isEmpty() ? m_info.serviceClassUuids().first().toString() : QString();
+}
+
+void PeluxBluetoothDevice::setStatus(PeluxDeviceManagerEnums::ConnectionStatus status)
+{
+    if (m_btLocalDevice.isNull()) { // BT link gone
+        updateStatus(PeluxDeviceManagerEnums::Disconnected);
+        return;
+    }
+
+    if (status == PeluxDeviceManagerEnums::Connected) { // connect + pair (optional)
+        if (pairingStatus() == QBluetoothLocalDevice::Unpaired) { // let's pair first
+            updateStatus(PeluxDeviceManagerEnums::Connecting);
+            connect(m_btLocalDevice.data(), &QBluetoothLocalDevice::pairingFinished,
+                    [this](const QBluetoothAddress &address, QBluetoothLocalDevice::Pairing pairing) {
+                qInfo() << "!! Pairing finished with:" << address.toString() << id();
+                if (address == m_info.device().address()) {
+                    if (pairing == QBluetoothLocalDevice::Paired || pairing == QBluetoothLocalDevice::AuthorizedPaired) {
+                        connectToSocket();
+                    }
+                }
+            });
+            qInfo() << "!!! Request pairing with:" << m_info.device().address();
+            m_btLocalDevice->requestPairing(m_info.device().address(), QBluetoothLocalDevice::AuthorizedPaired);
+        } else { // already paired, let's just connect to the socket
+            connectToSocket();
+        }
+    } else if (status == PeluxDeviceManagerEnums::Disconnected) { // disconnect
+        updateStatus(PeluxDeviceManagerEnums::Disconnecting);
+        disconnectFromSocket();
+    } else if (status == PeluxDeviceManagerEnums::Unpaired) { // unpair
+        if (pairingStatus() > QBluetoothLocalDevice::Unpaired) {
+            connect(m_btLocalDevice.data(), &QBluetoothLocalDevice::pairingFinished,
+                    [this](const QBluetoothAddress &address, QBluetoothLocalDevice::Pairing pairing) {
+                if (address == m_info.device().address() && pairing == QBluetoothLocalDevice::Unpaired) {
+                    updateStatus(PeluxDeviceManagerEnums::Unpaired);
+                }
+            });
+            m_btLocalDevice->requestPairing(m_info.device().address(), QBluetoothLocalDevice::Unpaired);
+        }
+    }
+}
+
+void PeluxBluetoothDevice::connectToSocket()
+{
+    if (!m_info.isValid()) {
+        qWarning() << Q_FUNC_INFO << "!!! Invalid BT service info";
+        return;
+    }
+    updateStatus(PeluxDeviceManagerEnums::Connecting);
+
+    m_socket.reset(new QBluetoothSocket(m_info.socketProtocol(), this));
+    connect(m_socket.data(), &QBluetoothSocket::connected, [this]() {
+        qInfo() << "!!! Service connected:" << id();
+        updateStatus(PeluxDeviceManagerEnums::Connected);
+    });
+    connect(m_socket.data(), &QBluetoothSocket::disconnected, [this]() {
+        qInfo() << "!!! Service disconnected:" << id();
+        updateStatus(PeluxDeviceManagerEnums::Disconnected);
+    });
+    connect(m_socket.data(), QOverload<QBluetoothSocket::SocketError>::of(&QBluetoothSocket::error),
+            [this](QBluetoothSocket::SocketError error) {
+        qWarning() << "Socket error:" << error << m_socket->errorString();
+    });
+    m_socket->connectToService(m_info.device().address(), m_info.serviceClassUuids().first());
+}
+
+void PeluxBluetoothDevice::disconnectFromSocket()
+{
+    if (!m_socket) {
+        qWarning() << Q_FUNC_INFO << "!!! Invalid socket info";
+        return;
+    }
+
+    m_socket->disconnectFromService();
+    //m_socket->close();
+    disconnect(m_socket.data());
+}
+
+void PeluxBluetoothDevice::checkConnectionStatus()
+{
+    switch (pairingStatus()) {
+    case QBluetoothLocalDevice::Unpaired:
+        updateStatus(PeluxDeviceManagerEnums::Unpaired);
+        break;
+    case QBluetoothLocalDevice::Paired:
+        updateStatus(PeluxDeviceManagerEnums::Paired);
+        break;
+    case QBluetoothLocalDevice::AuthorizedPaired:
+        updateStatus(PeluxDeviceManagerEnums::PairedAuthorized);
+        break;
+    default:
+        break;
+    }
+}
+
+void PeluxBluetoothDevice::updateStatus(PeluxDeviceManagerEnums::ConnectionStatus status)
+{
+    if (m_status != status) {
+        m_status = status;
+        Q_EMIT statusChanged(m_status);
+    }
+}
+
+QBluetoothLocalDevice::Pairing PeluxBluetoothDevice::pairingStatus() const
+{
+    if (m_btLocalDevice.isNull()) {
+        return QBluetoothLocalDevice::Unpaired;
+    }
+
+    return m_btLocalDevice->pairingStatus(m_info.device().address());
+}

--- a/src/lib/bluetooth/peluxbtdevice.h
+++ b/src/lib/bluetooth/peluxbtdevice.h
@@ -23,17 +23,19 @@
 
 #pragma once
 
-#include <Solid/Device>
-#include <Solid/SolidNamespace>
+#include <QPointer>
+#include <QBluetoothServiceInfo>
+#include <QBluetoothSocket>
+#include <QBluetoothLocalDevice>
 
 #include "peluxdevice.h"
 
-class PeluxSolidDevice : public PeluxDevice
+class PeluxBluetoothDevice : public PeluxDevice
 {
     Q_OBJECT
 public:
-    explicit PeluxSolidDevice(const Solid::Device &solidDevice, QObject * parent);
-    ~PeluxSolidDevice() = default;
+    explicit PeluxBluetoothDevice(const QBluetoothServiceInfo &btInfo, QBluetoothLocalDevice *btLocalDev, QObject * parent);
+    ~PeluxBluetoothDevice() = default;
 
     QString id() const override;
     QString parentId() const override;
@@ -47,16 +49,18 @@ public:
     QString device() const override;
     bool isRemovable() const override;
     PeluxDeviceManagerEnums::DriveType driveType() const override;
+    QString uuid() const override;
 
     void setStatus(PeluxDeviceManagerEnums::ConnectionStatus status) override;
-
-private Q_SLOTS:
-    void onStorageResult(Solid::ErrorType error, const QVariant &errorData);
 
 private:
     void checkConnectionStatus();
     void updateStatus(PeluxDeviceManagerEnums::ConnectionStatus status);
-
-    Solid::Device m_device;
-    QString m_id; // store the ID separately as the underlying Solid::Device might be gone anytime
+    void connectToSocket();
+    void disconnectFromSocket();
+    QBluetoothLocalDevice::Pairing pairingStatus() const;
+    QBluetoothServiceInfo m_info;
+    QString m_id; // store the ID separately as the underlying BtDevice might be gone anytime
+    QScopedPointer<QBluetoothSocket> m_socket;
+    QPointer<QBluetoothLocalDevice> m_btLocalDevice;
 };

--- a/src/lib/bluetooth/rfkill.cpp
+++ b/src/lib/bluetooth/rfkill.cpp
@@ -1,0 +1,264 @@
+/*
+ * BluezQt - Asynchronous Bluez wrapper library
+ *
+ * Copyright (C) 2015 David Rosca <nowrep@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) version 3, or any
+ * later version accepted by the membership of KDE e.V. (or its
+ * successor approved by the membership of KDE e.V.), which shall
+ * act as a proxy defined in Section 6 of version 3 of the license.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "rfkill.h"
+
+#ifdef Q_OS_LINUX
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdint.h>
+#endif
+
+#include <QSocketNotifier>
+#include <QDebug>
+
+namespace BluezQt
+{
+
+#ifdef Q_OS_LINUX
+enum rfkill_type {
+    RFKILL_TYPE_ALL = 0,
+    RFKILL_TYPE_WLAN,
+    RFKILL_TYPE_BLUETOOTH,
+    RFKILL_TYPE_UWB,
+    RFKILL_TYPE_WIMAX,
+    RFKILL_TYPE_WWAN
+};
+
+enum rfkill_operation {
+    RFKILL_OP_ADD = 0,
+    RFKILL_OP_DEL,
+    RFKILL_OP_CHANGE,
+    RFKILL_OP_CHANGE_ALL
+};
+
+struct rfkill_event {
+    quint32 idx;
+    quint8 type;
+    quint8 op;
+    quint8 soft;
+    quint8 hard;
+};
+#endif
+
+Rfkill::Rfkill(QObject *parent)
+    : QObject(parent)
+    , m_readFd(-1)
+    , m_writeFd(-1)
+    , m_state(Unknown)
+{
+    init();
+}
+
+Rfkill::~Rfkill()
+{
+#ifdef Q_OS_LINUX
+    if (m_readFd != -1) {
+        ::close(m_readFd);
+    }
+
+    if (m_writeFd != -1) {
+        ::close(m_writeFd);
+    }
+#endif
+}
+
+Rfkill::State Rfkill::state() const
+{
+    return m_state;
+}
+
+bool Rfkill::block()
+{
+    if (m_state == SoftBlocked || m_state == HardBlocked) {
+        return true;
+    }
+
+    if (m_state != Unblocked) {
+        return false;
+    }
+
+    return setSoftBlock(1);
+}
+
+bool Rfkill::unblock()
+{
+    qInfo() << "State when unblocking" << m_state;
+
+    if (m_state == Unblocked) {
+        return true;
+    }
+
+    if (m_state == HardBlocked) {
+        return false;
+    }
+
+    return setSoftBlock(0);
+}
+
+void Rfkill::devReadyRead()
+{
+    State oldState = m_state;
+
+    updateRfkillDevices();
+
+    if (m_state != oldState) {
+        Q_EMIT stateChanged(m_state);
+    }
+}
+
+void Rfkill::init()
+{
+#ifdef Q_OS_LINUX
+    m_readFd = ::open("/dev/rfkill", O_RDONLY);
+
+    if (m_readFd == -1) {
+        qWarning() << "Cannot open /dev/rfkill for reading!";
+        return;
+    }
+
+    if (::fcntl(m_readFd, F_SETFL, O_NONBLOCK) < 0) {
+        ::close(m_readFd);
+        m_readFd = -1;
+        return;
+    }
+
+    updateRfkillDevices();
+
+    QSocketNotifier *notifier = new QSocketNotifier(m_readFd, QSocketNotifier::Read, this);
+    connect(notifier, &QSocketNotifier::activated, this, &Rfkill::devReadyRead);
+#endif
+}
+
+bool Rfkill::openForWriting()
+{
+#ifndef Q_OS_LINUX
+    return false;
+#else
+    if (m_writeFd != -1) {
+        return true;
+    }
+
+    m_writeFd = ::open("/dev/rfkill", O_WRONLY);
+
+    if (m_writeFd == -1) {
+        qWarning() << "Cannot open /dev/rfkill for writing!";
+        return false;
+    }
+
+    if (::fcntl(m_writeFd, F_SETFL, O_NONBLOCK) < 0) {
+        ::close(m_writeFd);
+        m_writeFd = -1;
+        return false;
+    }
+
+    return true;
+#endif
+}
+
+#ifdef Q_OS_LINUX
+static Rfkill::State getState(const rfkill_event &event)
+{
+    if (event.hard) {
+        return Rfkill::HardBlocked;
+    } else if (event.soft) {
+        return Rfkill::SoftBlocked;
+    }
+    return Rfkill::Unblocked;
+}
+#endif
+
+void Rfkill::updateRfkillDevices()
+{
+#ifdef Q_OS_LINUX
+    if (m_readFd == -1) {
+        return;
+    }
+
+    rfkill_event event;
+    while (::read(m_readFd, &event, sizeof(event)) == sizeof(event)) {
+        if (event.type != RFKILL_TYPE_BLUETOOTH) {
+            continue;
+        }
+
+        switch (event.op) {
+        case RFKILL_OP_ADD:
+        case RFKILL_OP_CHANGE:
+            m_devices[event.idx] = getState(event);
+            break;
+
+        case RFKILL_OP_DEL:
+            m_devices.remove(event.idx);
+            break;
+
+        case RFKILL_OP_CHANGE_ALL:
+            Q_FOREACH (quint32 id, m_devices.keys()) {
+                m_devices[id] = getState(event);
+            }
+            break;
+
+        default:
+            break;
+        }
+    }
+
+    // Update global state
+    m_state = Unknown;
+
+    Q_FOREACH (State state, m_devices) { // krazy:exclude=foreach
+        Q_ASSERT(state != Unknown);
+
+        if (m_state == Unknown) {
+            m_state = state;
+        } else if (state > m_state) {
+            m_state = state;
+        }
+    }
+
+    qDebug() << "Rfkill global state changed:" << m_state;
+#endif
+}
+
+bool Rfkill::setSoftBlock(quint8 soft)
+{
+#ifndef Q_OS_LINUX
+    Q_UNUSED(soft)
+    return false;
+#else
+    if (!openForWriting()) {
+        return false;
+    }
+
+    rfkill_event event;
+    ::memset(&event, 0, sizeof(event));
+    event.op = RFKILL_OP_CHANGE_ALL;
+    event.type = RFKILL_TYPE_BLUETOOTH;
+    event.soft = soft;
+
+    bool ret = ::write(m_writeFd, &event, sizeof(event)) == sizeof(event);
+    qDebug() << "Setting Rfkill soft block succeeded:" << ret;
+    return ret;
+#endif
+}
+
+} // namespace BluezQt

--- a/src/lib/bluetooth/rfkill.h
+++ b/src/lib/bluetooth/rfkill.h
@@ -1,0 +1,72 @@
+/*
+ * BluezQt - Asynchronous Bluez wrapper library
+ *
+ * Copyright (C) 2015 David Rosca <nowrep@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) version 3, or any
+ * later version accepted by the membership of KDE e.V. (or its
+ * successor approved by the membership of KDE e.V.), which shall
+ * act as a proxy defined in Section 6 of version 3 of the license.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef BLUEZQT_RFKILL_H
+#define BLUEZQT_RFKILL_H
+
+#include <QHash>
+#include <QObject>
+
+namespace BluezQt
+{
+
+class Rfkill : public QObject
+{
+    Q_OBJECT
+
+public:
+    enum State {
+        Unblocked = 0,
+        SoftBlocked = 1,
+        HardBlocked = 2,
+        Unknown = 3
+    };
+    Q_ENUM(State)
+
+    explicit Rfkill(QObject *parent = nullptr);
+    ~Rfkill();
+
+    State state() const;
+    bool block();
+    bool unblock();
+
+Q_SIGNALS:
+    void stateChanged(State state);
+
+private Q_SLOTS:
+    void devReadyRead();
+
+private:
+    void init();
+    bool openForWriting();
+    void updateRfkillDevices();
+    bool setSoftBlock(quint8 soft);
+
+    int m_readFd;
+    int m_writeFd;
+    State m_state;
+    QHash<quint32, State> m_devices;
+};
+
+} // namespace BluezQt
+
+#endif // BLUEZQT_RFKILL_H

--- a/src/lib/lib.pro
+++ b/src/lib/lib.pro
@@ -4,7 +4,7 @@
 #
 #-------------------------------------------------
 
-QT += quick Solid
+QT += quick Solid bluetooth
 CONFIG += c++11 create_prl no_keywords
 
 TARGET = PeluxDeviceManager
@@ -27,7 +27,10 @@ SOURCES += \
         peluxdevicemanager.cpp \
     peluxdevice.cpp \
     solid/solidbackend.cpp \
-    solid/peluxsoliddevice.cpp
+    solid/peluxsoliddevice.cpp \
+    bluetooth/bluetoothbackend.cpp \
+    bluetooth/peluxbtdevice.cpp \
+    bluetooth/rfkill.cpp
 
 HEADERS += \
         peluxdevicemanager.h \
@@ -36,7 +39,10 @@ HEADERS += \
     peluxdevice.h \
     peluxdevicemanagerenums.h \
     solid/solidbackend.h \
-    solid/peluxsoliddevice.h
+    solid/peluxsoliddevice.h \
+    bluetooth/bluetoothbackend.h \
+    bluetooth/peluxbtdevice.h \
+    bluetooth/rfkill.h
 
 target.path = $$[QT_INSTALL_LIBS]
 INSTALLS += target

--- a/src/lib/peluxdevice.cpp
+++ b/src/lib/peluxdevice.cpp
@@ -28,7 +28,22 @@ PeluxDevice::PeluxDevice(QObject *parent)
 {
 }
 
+QString PeluxDevice::uuid() const
+{
+    return QString();
+}
+
 PeluxDeviceManagerEnums::ConnectionStatus PeluxDevice::status() const
 {
     return m_status;
+}
+
+void PeluxDevice::connectDevice()
+{
+    setStatus(PeluxDeviceManagerEnums::Connected);
+}
+
+void PeluxDevice::disconnectDevice()
+{
+    setStatus(PeluxDeviceManagerEnums::Disconnected);
 }

--- a/src/lib/peluxdevice.h
+++ b/src/lib/peluxdevice.h
@@ -61,9 +61,13 @@ public:
     virtual QString device() const = 0;
     virtual bool isRemovable() const = 0;
     virtual PeluxDeviceManagerEnums::DriveType driveType() const = 0;
+    virtual QString uuid() const;
 
     PeluxDeviceManagerEnums::ConnectionStatus status() const;
     virtual void setStatus(PeluxDeviceManagerEnums::ConnectionStatus status) = 0;
+
+    Q_INVOKABLE void connectDevice();
+    Q_INVOKABLE void disconnectDevice();
 
 protected:
     PeluxDeviceManagerEnums::ConnectionStatus m_status{PeluxDeviceManagerEnums::UnknownConnectionStatus};

--- a/src/lib/peluxdevicemanager.h
+++ b/src/lib/peluxdevicemanager.h
@@ -36,6 +36,7 @@ class PELUXDEVICEMANAGERSHARED_EXPORT PeluxDeviceManager: public QAbstractListMo
     Q_OBJECT
 
     Q_PROPERTY(int count READ rowCount NOTIFY countChanged)
+    Q_PROPERTY(bool btDiscoveryActive READ isBtDiscoveryActive NOTIFY isBtDiscoveryActiveChanged)
 
 public:
     enum Roles {
@@ -51,6 +52,8 @@ public:
         MountpointRole,
         DeviceRole,
         RemovableRole,
+        DriveTypeRole,
+        UuidRole,
     };
     Q_ENUM(Roles)
 
@@ -65,10 +68,24 @@ public:
     Q_INVOKABLE QVector<PeluxDevice *> allDevices() const;
     Q_INVOKABLE QVector<PeluxDevice *> allDevicesOfType(PeluxDeviceManagerEnums::DeviceType type) const;
 
+    Q_INVOKABLE void startBtDiscovery();
+    Q_INVOKABLE void stopBtDiscovery();
+    bool isBtDiscoveryActive() const;
+    /**
+      * To be called by the user to confirm the pairing request
+      */
+    Q_INVOKABLE void confirmPairing(bool accept);
+
 Q_SIGNALS:
     void deviceAdded(PeluxDevice * device);
     void deviceRemoved(PeluxDevice * device);
     void countChanged();
+    void isBtDiscoveryActiveChanged(bool active);
+
+    /**
+      * To be displayed to the user upon pairing a device
+      */
+    void pairingConfirmation(const QString &address, const QString &pin);
 
 private:
     Q_DISABLE_COPY(PeluxDeviceManager)

--- a/src/lib/peluxdevicemanager_p.h
+++ b/src/lib/peluxdevicemanager_p.h
@@ -26,6 +26,7 @@
 #include <QHash>
 
 #include "peluxdevice.h"
+#include "bluetooth/bluetoothbackend.h"
 
 class PeluxDeviceManager;
 
@@ -38,7 +39,10 @@ public:
     PeluxDeviceManagerPrivate(PeluxDeviceManager *qptr);
     ~PeluxDeviceManagerPrivate();
     void initialize();
+    void listenToDevice(PeluxDevice *dev);
 
     QHash<int, QByteArray> roles;
     QVector<PeluxDevice *> devices;
+
+    BluetoothBackend *btBackend{nullptr};
 };

--- a/src/lib/peluxdevicemanagerenums.h
+++ b/src/lib/peluxdevicemanagerenums.h
@@ -46,7 +46,10 @@ public:
         UnknownConnectionStatus = 0,
         Disconnecting,
         Disconnected,
+        Unpaired,
         Connecting,
+        Paired,
+        PairedAuthorized,
         Connected,
     };
     Q_ENUM(ConnectionStatus)

--- a/src/lib/solid/peluxsoliddevice.cpp
+++ b/src/lib/solid/peluxsoliddevice.cpp
@@ -156,18 +156,18 @@ void PeluxSolidDevice::setStatus(PeluxDeviceManagerEnums::ConnectionStatus statu
 {
     if (status != m_status && m_device.is<Solid::StorageAccess>()) {
         if (status == PeluxDeviceManagerEnums::Connected) {
-            m_device.as<Solid::StorageAccess>()->setup();
             updateStatus(PeluxDeviceManagerEnums::Connecting);
+            m_device.as<Solid::StorageAccess>()->setup();
         } else if (status == PeluxDeviceManagerEnums::Disconnected) {
-            m_device.as<Solid::StorageAccess>()->teardown();
             updateStatus(PeluxDeviceManagerEnums::Disconnecting);
+            m_device.as<Solid::StorageAccess>()->teardown();
         }
     }
 }
 
 void PeluxSolidDevice::onStorageResult(Solid::ErrorType error, const QVariant &errorData)
 {
-    qWarning() << Q_FUNC_INFO << "Mount/unmount operation ended with status:" << error << errorData.toString();
+    qDebug() << Q_FUNC_INFO << "Mount/unmount operation ended with status:" << error << errorData.toString();
 }
 
 void PeluxSolidDevice::checkConnectionStatus()


### PR DESCRIPTION
The Bluetooth backend uses QtBluetooth module, mention it in README.

The backend is capable of discovering and pairing of BT devices, 
and connecting to its various offered services. 